### PR TITLE
Make errors during setup and request events exit CLI with error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixes fetches that were successful but resulted in errors during the response.success event were causing response.error to be invoked.
+
+### Changed
+- Errors during response.success or response.error will now cause the overall crawl to fail, as this indicates a problem with the invoking code. 
+
 ## [1.1.1] - 2018-07-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bluebird": "^3.5.1",
     "chalk": "^2.3.0",
     "debug": "^3.1.0",
-    "events-async": "^1.1.0",
+    "events-async": "^1.2.1",
     "forever-agent": "^0.6.1",
     "junit-report-builder": "^1.2.0",
     "markdown-table": "^1.1.1",
@@ -72,7 +72,6 @@
     }
   },
   "jest": {
-    "collectCoverage": true,
     "testPathIgnorePatterns": [
       "/node_modules/",
       "/dist/"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     }
   },
   "jest": {
+    "collectCoverage": true,
     "testPathIgnorePatterns": [
       "/node_modules/",
       "/dist/"


### PR DESCRIPTION
This PR resolves two issues:

1. Errors thrown during the `setup` phase did not trigger the CLI process to exit with an error code.
2. Errors thrown during `request.success` or `request.fail` would end up appearing as though the request itself had failed, while they are actually logical errors in the configuration code.  They now fail the CLI process as well. 